### PR TITLE
rename "mp_(m|f)_0" dlc to "basegame" for clarity

### DIFF
--- a/torsos/index.js
+++ b/torsos/index.js
@@ -29,50 +29,59 @@ function processNames(files) {
 
 const male = {
   0: [
-    { dlc: "mp_m_0", drawable: 0 },
+    { dlc: "basegame", drawable: 0 },
     ...processNames(glob.sync("./male/0/*.png")),
   ],
   1: [
-    { dlc: "mp_m_0", drawable: 1 },
+    { dlc: "basegame", drawable: 1 },
     ...processNames(glob.sync("./male/1/*.png")),
   ],
   2: [
-    { dlc: "mp_m_0", drawable: 2 },
+    { dlc: "basegame", drawable: 2 },
     ...processNames(glob.sync("./male/2/*.png")),
   ],
   4: [
-    { dlc: "mp_m_0", drawable: 4 },
+    { dlc: "basegame", drawable: 4 },
     ...processNames(glob.sync("./male/4/*.png")),
   ],
   5: [
-    { dlc: "mp_m_0", drawable: 5 },
+    { dlc: "basegame", drawable: 5 },
     ...processNames(glob.sync("./male/5/*.png")),
   ],
   6: [
-    { dlc: "mp_m_0", drawable: 6 },
+    { dlc: "basegame", drawable: 6 },
     ...processNames(glob.sync("./male/6/*.png")),
   ],
-  7: [{ dlc: "mp_m_0", drawable: 7 }],
+  7: [
+    { dlc: "basegame", drawable: 7 },
+    ...processNames(glob.sync("./male/7/*.png")),
+  ],
   8: [
-    { dlc: "mp_m_0", drawable: 8 },
+    { dlc: "basegame", drawable: 8 },
     ...processNames(glob.sync("./male/8/*.png")),
   ],
-  9: [{ dlc: "mp_m_0", drawable: 9 }],
-  10: [{ dlc: "mp_m_0", drawable: 10 }],
+  9: [
+    { dlc: "basegame", drawable: 9 },
+    ...processNames(glob.sync("./male/9/*.png")),
+  ],
+  10: [
+    { dlc: "basegame", drawable: 10 },
+    ...processNames(glob.sync("./male/10/*.png")),
+  ],
   11: [
-    { dlc: "mp_m_0", drawable: 11 },
+    { dlc: "basegame", drawable: 11 },
     ...processNames(glob.sync("./male/11/*.png")),
   ],
   12: [
-    { dlc: "mp_m_0", drawable: 12 },
+    { dlc: "basegame", drawable: 12 },
     ...processNames(glob.sync("./male/12/*.png")),
   ],
   14: [
-    { dlc: "mp_m_0", drawable: 14 },
+    { dlc: "basegame", drawable: 14 },
     ...processNames(glob.sync("./male/14/*.png")),
   ],
   15: [
-    { dlc: "mp_m_0", drawable: 15 },
+    { dlc: "basegame", drawable: 15 },
     ...processNames(glob.sync("./male/15/*.png")),
   ],
   16: [...processNames(glob.sync("./male/16/*.png"))],
@@ -80,58 +89,67 @@ const male = {
 
 const female = {
   0: [
-    { dlc: "mp_f_0", drawable: 0 },
+    { dlc: "basegame", drawable: 0 },
     ...processNames(glob.sync("./female/0/*.png")),
   ],
   1: [
-    { dlc: "mp_f_0", drawable: 1 },
+    { dlc: "basegame", drawable: 1 },
     ...processNames(glob.sync("./female/1/*.png")),
   ],
   2: [
-    { dlc: "mp_f_0", drawable: 2 },
+    { dlc: "basegame", drawable: 2 },
     ...processNames(glob.sync("./female/2/*.png")),
   ],
   3: [
-    { dlc: "mp_f_0", drawable: 3 },
+    { dlc: "basegame", drawable: 3 },
     ...processNames(glob.sync("./female/3/*.png")),
   ],
   4: [
-    { dlc: "mp_f_0", drawable: 4 },
+    { dlc: "basegame", drawable: 4 },
     ...processNames(glob.sync("./female/4/*.png")),
   ],
   5: [
-    { dlc: "mp_f_0", drawable: 5 },
+    { dlc: "basegame", drawable: 5 },
     ...processNames(glob.sync("./female/5/*.png")),
   ],
   6: [
-    { dlc: "mp_f_0", drawable: 6 },
+    { dlc: "basegame", drawable: 6 },
     ...processNames(glob.sync("./female/6/*.png")),
   ],
   7: [
-    { dlc: "mp_f_0", drawable: 7 },
+    { dlc: "basegame", drawable: 7 },
     ...processNames(glob.sync("./female/7/*.png")),
   ],
-  8: [{ dlc: "mp_f_0", drawable: 8 }],
+  8: [
+    { dlc: "basegame", drawable: 8 },
+    ...processNames(glob.sync("./female/8/*.png")),
+  ],
   9: [
-    { dlc: "mp_f_0", drawable: 9 },
+    { dlc: "basegame", drawable: 9 },
     ...processNames(glob.sync("./female/9/*.png")),
   ],
-  10: [{ dlc: "mp_f_0", drawable: 10 }],
+  10: [
+    { dlc: "basegame", drawable: 10 },
+    ...processNames(glob.sync("./female/10/*.png")),
+  ],
   11: [
-    { dlc: "mp_f_0", drawable: 11 },
+    { dlc: "basegame", drawable: 11 },
     ...processNames(glob.sync("./female/11/*.png")),
   ],
   12: [
-    { dlc: "mp_f_0", drawable: 12 },
+    { dlc: "basegame", drawable: 12 },
     ...processNames(glob.sync("./female/12/*.png")),
   ],
-  13: [{ dlc: "mp_f_0", drawable: 13 }],
+  13: [
+    { dlc: "basegame", drawable: 13 },
+    ...processNames(glob.sync("./female/13/*.png")),
+  ],
   14: [
-    { dlc: "mp_f_0", drawable: 14 },
+    { dlc: "basegame", drawable: 14 },
     ...processNames(glob.sync("./female/14/*.png")),
   ],
   15: [
-    { dlc: "mp_f_0", drawable: 15 },
+    { dlc: "basegame", drawable: 15 },
     ...processNames(glob.sync("./female/15/*.png")),
   ],
   16: [...processNames(glob.sync("./male/16/*.png"))],


### PR DESCRIPTION
Also adds names processing to "missed" drawables. They're obviously not missed, but the function would return empty array anyways and it's better to be future proof, so in case those drawables are updated in the future, there is no need to change the script.